### PR TITLE
build(deps): adjust package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
 		"aggregator",
 		"api",
 		"typescript",
-		"sqlite"
+		"sqlite",
+		"tasks"
 	],
 	"type": "module",
 	"main": "dist/index.js",
@@ -43,8 +44,8 @@
 	"dependencies": {
 		"better-sqlite3": "^9.4.1",
 		"dotenv": "^16.4.5",
-		"drizzle-orm": "^0.45.2",
-		"fastify": "^5.8.1",
+		"drizzle-orm": "^0.33.0",
+		"fastify": "^5.8.5",
 		"fastify-plugin": "^5.1.0",
 		"luxon": "^3.5.0",
 		"node-ical": "^0.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1273,10 +1273,10 @@ drizzle-kit@^0.24.0:
     esbuild "^0.19.7"
     esbuild-register "^3.5.0"
 
-drizzle-orm@^0.45.2:
-  version "0.45.2"
-  resolved "https://registry.yarnpkg.com/drizzle-orm/-/drizzle-orm-0.45.2.tgz#37eb5e4e6bd1309cb8d5414de09632d8f82d8a65"
-  integrity sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==
+drizzle-orm@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/drizzle-orm/-/drizzle-orm-0.33.0.tgz#ece81e3e85f7559b5f7c01fc09e654e9a2f087fe"
+  integrity sha512-SHy72R2Rdkz0LEq0PSG/IdvnT3nGiWuRk+2tXZQ90GVq/XQhpCzu/EFT3V2rox+w8MlkBQxifF8pCStNYnERfA==
 
 dunder-proto@^1.0.1:
   version "1.0.1"
@@ -1643,10 +1643,10 @@ fastify-plugin@^5.1.0:
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-5.1.0.tgz#7083e039d6418415f9a669f8c25e72fc5bf2d3e7"
   integrity sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==
 
-fastify@^5.8.1:
-  version "5.8.1"
-  resolved "https://registry.yarnpkg.com/fastify/-/fastify-5.8.1.tgz#777eef0143c0ba5e3c71076224455885f303504f"
-  integrity sha512-y0kicFvvn7CYWoPOVLOcvn4YyKQz03DIY7UxmyOy21/J8eXm09R+tmb+tVDBW5h+pja30cHI5dqUcSlvY86V2A==
+fastify@^5.8.5:
+  version "5.8.5"
+  resolved "https://registry.yarnpkg.com/fastify/-/fastify-5.8.5.tgz#c452224295e0ca550bcd0efc3f7d3e90e9c11955"
+  integrity sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==
   dependencies:
     "@fastify/ajv-compiler" "^4.0.5"
     "@fastify/error" "^4.0.0"


### PR DESCRIPTION
Pin Drizzle ORM to 0.33, bump Fastify, and tag tasks